### PR TITLE
feature: add Electron simple browser e2e test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,16 @@ jobs:
         run: npm run e2e:headless
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Cache Electron app
+        uses: actions/cache@v4
+        if: matrix.os == 'ubuntu-24.04'
+        with:
+          path: packages/e2e/.test-with-playwright/electron
+          key: ${{ runner.os }}-simple-browser-electron-${{ hashFiles('packages/server/package-lock.json') }}
+      - name: Electron e2e
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/e2e
+        run: xvfb-run -a npm run e2e:electron
       - name: measure
         run: npm run measure
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,6 +47,16 @@ jobs:
         run: npm run e2e:headless
         env:
           PLAYWRIGHT_BROWSERS_PATH: 0
+      - name: Cache Electron app
+        uses: actions/cache@v4
+        if: matrix.os == 'ubuntu-24.04'
+        with:
+          path: packages/e2e/.test-with-playwright/electron
+          key: ${{ runner.os }}-simple-browser-electron-${{ hashFiles('packages/server/package-lock.json') }}
+      - name: Electron e2e
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/e2e
+        run: xvfb-run -a npm run e2e:electron
       - name: measure
         run: npm run measure
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 test-results
+.test-with-playwright
 .vscode
 .tmp
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import * as config from '@lvce-editor/eslint-config'
 export default [
   ...config.default,
   {
-    ignores: ['packages/e2e/playwright.config.ts'],
+    ignores: ['packages/e2e/.test-with-playwright/**', 'packages/e2e/playwright.config.ts'],
   },
   {
     files: ['**/*.ts'],
@@ -21,6 +21,12 @@ export default [
     files: ['**/*.test.ts'],
     rules: {
       'jest/no-restricted-jest-methods': 'off',
+    },
+  },
+  {
+    files: ['packages/e2e/electron/**/*.ts'],
+    rules: {
+      'e2e/no-imports': 'off',
     },
   },
 ]

--- a/packages/e2e/electron/src/_simpleBrowser.ts
+++ b/packages/e2e/electron/src/_simpleBrowser.ts
@@ -1,0 +1,57 @@
+import type { Page } from '@playwright/test'
+
+const navigationTimeout = 15_000
+
+const isExpectedPage = (candidate: Page, expectedUrl: string): boolean => {
+  return candidate.url().startsWith(expectedUrl)
+}
+
+const waitForWebContentsPage = async (page: Page, expectedUrl: string): Promise<Page> => {
+  const context = page.context()
+  const end = Date.now() + navigationTimeout
+  while (Date.now() < end) {
+    const webContentsPage = context.pages().find((candidate) => isExpectedPage(candidate, expectedUrl))
+    if (webContentsPage) {
+      await webContentsPage.waitForLoadState('domcontentloaded')
+      return webContentsPage
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  const pageUrls = context.pages().map((candidate) => candidate.url())
+  throw new Error(`Simple Browser WebContentsView did not navigate to ${expectedUrl}. Open pages: ${pageUrls.join(', ')}`)
+}
+
+export const show = async (page: Page): Promise<void> => {
+  await page.locator('.Workbench').waitFor({ state: 'visible' })
+  await page.bringToFront()
+  const shortcut = process.platform === 'darwin' ? 'Meta+Shift+P' : 'Control+Shift+P'
+  await page.keyboard.press(shortcut)
+  const quickPick = page.locator('.QuickPick')
+  await quickPick.waitFor({ state: 'visible' })
+  const input = quickPick.locator('input')
+  await input.fill('>Simple Browser: Open')
+  const command = quickPick.getByRole('option', { exact: true, name: 'Simple Browser: Open' })
+  await command.waitFor({ state: 'visible' })
+  await page.keyboard.press('Enter')
+  await page.locator('.SimpleBrowser').waitFor({ state: 'visible' })
+}
+
+export const openUrl = async (page: Page, url: string): Promise<Page> => {
+  const input = page.locator('.SimpleBrowserHeader input.InputBox')
+  await input.fill(url)
+  await input.press('Enter')
+  return waitForWebContentsPage(page, url)
+}
+
+export const injectJavaScriptCode = async <T>(webContentsPage: Page, code: string): Promise<T> => {
+  return webContentsPage.evaluate(code)
+}
+
+export const getHtml = async (webContentsPage: Page): Promise<string> => {
+  return injectJavaScriptCode(webContentsPage, 'document.documentElement.outerHTML')
+}
+
+export const getComputedStyle = async (webContentsPage: Page, selector: string, property: string): Promise<string> => {
+  const code = `getComputedStyle(document.querySelector(${JSON.stringify(selector)})).getPropertyValue(${JSON.stringify(property)})`
+  return injectJavaScriptCode(webContentsPage, code)
+}

--- a/packages/e2e/electron/src/_testServer.ts
+++ b/packages/e2e/electron/src/_testServer.ts
@@ -1,0 +1,43 @@
+import { createServer, type Server } from 'node:http'
+
+export interface TestServer {
+  readonly close: () => Promise<void>
+  readonly url: string
+}
+
+const listen = async (server: Server): Promise<number> => {
+  const { promise, reject, resolve } = Promise.withResolvers<number>()
+  server.once('error', reject)
+  server.listen(0, '127.0.0.1', () => {
+    server.off('error', reject)
+    const address = server.address()
+    if (!address || typeof address === 'string') {
+      reject(new Error('Failed to determine test server port'))
+      return
+    }
+    resolve(address.port)
+  })
+  return promise
+}
+
+export const start = async (): Promise<TestServer> => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    response.end('<!doctype html><html><body><h1 id="greeting">hello world</h1></body></html>')
+  })
+  const port = await listen(server)
+  return {
+    close: async (): Promise<void> => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+      })
+    },
+    url: `http://127.0.0.1:${port}`,
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.web-contents-view.ts
+++ b/packages/e2e/electron/src/simple-browser.web-contents-view.ts
@@ -1,0 +1,26 @@
+import type { expect as PlaywrightExpect, Page } from '@playwright/test'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+interface ElectronTestContext {
+  readonly expect: typeof PlaywrightExpect
+  readonly page: Page
+}
+
+export const name = 'simple-browser.web-contents-view'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await TestServer.start()
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, server.url)
+
+    const heading = webContentsPage.locator('#greeting')
+    await expect(heading).toBeVisible()
+    await expect(heading).toHaveText('hello world')
+    expect(await SimpleBrowser.getHtml(webContentsPage)).toContain('<h1 id="greeting">hello world</h1>')
+    expect(await SimpleBrowser.getComputedStyle(webContentsPage, '#greeting', 'display')).toBe('block')
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/package-lock.json
+++ b/packages/e2e/package-lock.json
@@ -9,98 +9,53 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright": "^2.17.0",
+        "@lvce-editor/test-with-playwright": "^22.7.1",
         "@playwright/test": "^1.57.0",
         "@types/node": "^25.0.3"
       }
     },
-    "node_modules/@lvce-editor/assert": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.3.0.tgz",
-      "integrity": "sha512-hrwqjOPi3vLuFJk5IqGl/M9H5QDZjTAiQsyFO15S07D2f42zZAdAwUrgLU2CAEPXgL6ZIJ6j7nT+nWOK5y4++w==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-1.2.0.tgz",
-      "integrity": "sha512-L9RCl+cOXyIlugI6od3uDqr4cGo0nVOfbgCTzYmR2WKKZE+iETf1A939b1Mv0WwiEiv42bSw7DJGHelaN6STKA==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/ipc": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-13.8.0.tgz",
-      "integrity": "sha512-csJES3gmOYz0uj4ymaozohghKIsSTMTSh1piON+7C1Wxe4flmXdKAq8B0FNJDxgsBICGOEmOZK+UPZZxJGndHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.3.0",
-        "@lvce-editor/verror": "^1.6.0",
-        "@lvce-editor/web-socket-server": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/json-rpc": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-5.4.0.tgz",
-      "integrity": "sha512-P/nfNVooJ9PuATLKWvRbZJvkOKy6csA39ifVc50tl+P+Z3zzBS+gSeAG+/IxxaYxc/JUFHusr3GxJqrLnU1CdQ==",
-      "license": "MIT"
-    },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-2.17.0.tgz",
-      "integrity": "sha512-OCEUx8ctkrLsBxDbnQhr/cepf6ILtn6z68eA/IfrD1Es7ol10es63Wav98/sKT+0Mk41Td/aNrqaB0yuIqOx4g==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.7.1.tgz",
+      "integrity": "sha512-GCwbV6VMNuKhd5jr86T/Js/cHQ3FT2yuy2fIZ4gT1mEZfsmbdokeH/IpHp5vh9ho9V8SYvBVbdxJatM1qH2qyw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.3.0",
-        "@lvce-editor/command": "^1.2.0",
-        "@lvce-editor/ipc": "^13.8.0",
-        "@lvce-editor/json-rpc": "^5.4.0",
-        "@lvce-editor/test-with-playwright-worker": "2.17.0",
-        "@lvce-editor/verror": "^1.6.0",
-        "minimist": "^1.2.8"
+        "@lvce-editor/test-with-playwright-worker": "22.7.1",
+        "@lvce-editor/test-worker": "^17.2.0"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-2.17.0.tgz",
-      "integrity": "sha512-LUDYJutV3nlns1dPSXEyAkTE5Fq6oBUyKOFn7ajOSy/7eIE8FZcL6YNNvlMUBfhcEWyQQyH0Ru117V2XFM22qQ==",
+      "version": "22.7.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.7.1.tgz",
+      "integrity": "sha512-R0rtaaKTN/DGeSB4ZPVGMaFIKbHBacuJY47OCYrz2wvCTf5HqRCHgXfWDkZA/rR0ryw9LglEkm79o9I1QpKRyw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.3.0",
-        "@lvce-editor/command": "^1.2.0",
-        "@lvce-editor/ipc": "^13.8.0",
-        "@lvce-editor/json-rpc": "^5.4.0",
-        "@lvce-editor/verror": "^1.6.0",
-        "@playwright/test": "^1.52.0",
-        "get-port": "^7.1.0"
+        "@playwright/test": "1.61.1",
+        "get-port": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
-    "node_modules/@lvce-editor/verror": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/verror/-/verror-1.6.0.tgz",
-      "integrity": "sha512-/+z23uEXBgJCu8skpdtS3fxr94sI/ss2R85j3OMNoutIFFGJ97gRqJm5rZwMGPap5VcsTnf840InuV5oaVbKdw==",
+    "node_modules/@lvce-editor/test-worker": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.2.0.tgz",
+      "integrity": "sha512-H5+w/8+hSjE/BivDtlvOxWkmZNEUgxSDNiAeY58A8lHiAByNVvivjlvTo8c2Y3wLiyx8PeSXxNQaukWLdXueHA==",
       "license": "MIT"
     },
-    "node_modules/@lvce-editor/web-socket-server": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/web-socket-server/-/web-socket-server-1.4.0.tgz",
-      "integrity": "sha512-RkjlIDC4pfPkgBo4Ve2mlC0LpqsCiPGE6Uz3/V9oI3qH8fS/PGQ5yNplUph8r9LLoHIVeHtufv7gmiIzWIfOIg==",
-      "license": "MIT",
-      "dependencies": {
-        "ws": "^8.18.0"
-      }
-    },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -133,9 +88,9 @@
       }
     },
     "node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -144,22 +99,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -172,9 +118,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -188,27 +134,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
-    },
-    "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=.",
+    "e2e:electron": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --electron --only-extension=. --test-path=./electron --timeout=60000",
     "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --headless",
     "type-check": "tsc"
   },
@@ -14,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/test-with-playwright": "^2.17.0",
+    "@lvce-editor/test-with-playwright": "^22.7.1",
     "@playwright/test": "^1.57.0",
     "@types/node": "^25.0.3"
   }

--- a/packages/e2e/tsconfig.json
+++ b/packages/e2e/tsconfig.json
@@ -16,7 +16,8 @@
     "assumeChangesOnlyAffectDirectDependencies": true,
     "strict": true,
     "noImplicitAny": false,
-    "composite": true
+    "composite": true,
+    "allowImportingTsExtensions": true
   },
-  "include": ["src", "test"]
+  "include": ["electron/src", "src", "test"]
 }


### PR DESCRIPTION
Summary:
- exercise the real Simple Browser WebContentsView in Electron against a random-port localhost server
- assert rendered heading content, document HTML, and computed style through reusable helpers
- run and cache the Electron e2e test on Ubuntu CI using test-with-playwright 22.7.1