### PR TITLE
feature: add simple browser response e2e tests

### DIFF
--- a/packages/e2e/electron/src/_responseTest.ts
+++ b/packages/e2e/electron/src/_responseTest.ts
@@ -1,0 +1,23 @@
+import type { expect as PlaywrightExpect, Page } from '@playwright/test'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export interface ElectronTestContext {
+  readonly expect: typeof PlaywrightExpect
+  readonly page: Page
+}
+
+interface ResponseTestOptions extends TestServer.TestResponse {
+  readonly expectedText: string
+}
+
+export const run = async ({ expect, page }: ElectronTestContext, { expectedText, ...response }: ResponseTestOptions): Promise<void> => {
+  const server = await TestServer.start(TestServer.respond(response))
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, server.url)
+    await expect(webContentsPage.locator('body')).toHaveText(expectedText)
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/electron/src/_simpleBrowser.ts
+++ b/packages/e2e/electron/src/_simpleBrowser.ts
@@ -3,7 +3,17 @@ import type { Page } from '@playwright/test'
 const navigationTimeout = 15_000
 
 const isExpectedPage = (candidate: Page, expectedUrl: string): boolean => {
-  return candidate.url().startsWith(expectedUrl)
+  const candidateUrl = candidate.url()
+  if (candidateUrl.startsWith(expectedUrl)) {
+    return true
+  }
+  try {
+    const parsedUrl = new URL(candidateUrl)
+    const message = parsedUrl.searchParams.get('message') || ''
+    return parsedUrl.pathname.endsWith('/pages/error/error.html') && message.includes(expectedUrl)
+  } catch {
+    return false
+  }
 }
 
 const waitForWebContentsPage = async (page: Page, expectedUrl: string): Promise<Page> => {
@@ -36,11 +46,15 @@ export const show = async (page: Page): Promise<void> => {
   await page.locator('.SimpleBrowser').waitFor({ state: 'visible' })
 }
 
-export const openUrl = async (page: Page, url: string): Promise<Page> => {
+export const setUrl = async (page: Page, url: string): Promise<void> => {
   const input = page.locator('.SimpleBrowserHeader input.InputBox')
   await input.fill(url)
   await input.press('Enter')
-  return waitForWebContentsPage(page, url)
+}
+
+export const openUrl = async (page: Page, url: string, expectedUrl: string = url): Promise<Page> => {
+  await setUrl(page, url)
+  return waitForWebContentsPage(page, expectedUrl)
 }
 
 export const injectJavaScriptCode = async <T>(webContentsPage: Page, code: string): Promise<T> => {

--- a/packages/e2e/electron/src/_testServer.ts
+++ b/packages/e2e/electron/src/_testServer.ts
@@ -1,4 +1,11 @@
-import { createServer, type Server } from 'node:http'
+import { createServer, type RequestListener, type Server } from 'node:http'
+
+export interface TestResponse {
+  readonly body?: string
+  readonly headers?: Readonly<Record<string, string>>
+  readonly statusCode?: number
+  readonly statusMessage?: string
+}
 
 export interface TestServer {
   readonly close: () => Promise<void>
@@ -20,11 +27,24 @@ const listen = async (server: Server): Promise<number> => {
   return promise
 }
 
-export const start = async (): Promise<TestServer> => {
-  const server = createServer((_request, response) => {
-    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
-    response.end('<!doctype html><html><body><h1 id="greeting">hello world</h1></body></html>')
-  })
+export const respond = ({ body = '', headers = {}, statusCode = 200, statusMessage }: TestResponse): RequestListener => {
+  return (_request, response): void => {
+    if (statusMessage) {
+      response.writeHead(statusCode, statusMessage, headers)
+    } else {
+      response.writeHead(statusCode, headers)
+    }
+    response.end(body)
+  }
+}
+
+const defaultHandler = respond({
+  body: '<!doctype html><html><body><h1 id="greeting">hello world</h1></body></html>',
+  headers: { 'content-type': 'text/html; charset=utf-8' },
+})
+
+export const start = async (handler: RequestListener = defaultHandler): Promise<TestServer> => {
+  const server = createServer(handler)
   const port = await listen(server)
   return {
     close: async (): Promise<void> => {

--- a/packages/e2e/electron/src/simple-browser.connection-refused.ts
+++ b/packages/e2e/electron/src/simple-browser.connection-refused.ts
@@ -1,0 +1,17 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.connection-refused'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await TestServer.start()
+  const unreachableUrl = server.url
+  await server.close()
+
+  await SimpleBrowser.show(page)
+  const webContentsPage = await SimpleBrowser.openUrl(page, unreachableUrl)
+  const body = webContentsPage.locator('body')
+  await expect(body).toContainText("This site can't be reached")
+  await expect(body).toContainText('ERR_CONNECTION_REFUSED')
+}

--- a/packages/e2e/electron/src/simple-browser.empty-response.ts
+++ b/packages/e2e/electron/src/simple-browser.empty-response.ts
@@ -1,0 +1,20 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.empty-response'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await TestServer.start((request) => {
+    request.socket.destroy()
+  })
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, server.url)
+    const body = webContentsPage.locator('body')
+    await expect(body).toContainText('Site could not be loaded')
+    await expect(body).toContainText('ERR_EMPTY_RESPONSE')
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.recovers-after-connection-error.ts
+++ b/packages/e2e/electron/src/simple-browser.recovers-after-connection-error.ts
@@ -1,0 +1,27 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.recovers-after-connection-error'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const unavailableServer = await TestServer.start()
+  const unavailableUrl = unavailableServer.url
+  await unavailableServer.close()
+  const availableServer = await TestServer.start(
+    TestServer.respond({
+      body: '<!doctype html><html><body><h1>Server is available again</h1></body></html>',
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    }),
+  )
+  try {
+    await SimpleBrowser.show(page)
+    const errorPage = await SimpleBrowser.openUrl(page, unavailableUrl)
+    await expect(errorPage.locator('body')).toContainText("This site can't be reached")
+
+    const recoveredPage = await SimpleBrowser.openUrl(page, availableServer.url)
+    await expect(recoveredPage.locator('h1')).toHaveText('Server is available again')
+  } finally {
+    await availableServer.close()
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.response-200-json.ts
+++ b/packages/e2e/electron/src/simple-browser.response-200-json.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-200-json'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  const body = '{"status":"ok","items":[1,2,3]}'
+  await ResponseTest.run(context, {
+    body,
+    expectedText: body,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-200-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-200-text.ts
@@ -1,0 +1,11 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-200-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'plain text response',
+    expectedText: 'plain text response',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-204-empty.ts
+++ b/packages/e2e/electron/src/simple-browser.response-204-empty.ts
@@ -1,0 +1,32 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.response-204-empty'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const contentServer = await TestServer.start(
+    TestServer.respond({
+      body: '<!doctype html><html><body><h1>Existing content</h1></body></html>',
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    }),
+  )
+  const { promise: noContentRequested, resolve: resolveNoContentRequested } = Promise.withResolvers<void>()
+  const noContentServer = await TestServer.start((_request, response) => {
+    response.writeHead(204)
+    response.end()
+    resolveNoContentRequested()
+  })
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, contentServer.url)
+    await expect(webContentsPage.locator('h1')).toHaveText('Existing content')
+
+    await SimpleBrowser.setUrl(page, noContentServer.url)
+    await noContentRequested
+    await expect(webContentsPage.locator('h1')).toHaveText('Existing content')
+    expect(webContentsPage.url()).toBe(`${contentServer.url}/`)
+  } finally {
+    await Promise.all([contentServer.close(), noContentServer.close()])
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.response-206-partial-content.ts
+++ b/packages/e2e/electron/src/simple-browser.response-206-partial-content.ts
@@ -1,0 +1,15 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-206-partial-content'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'partial content',
+    expectedText: 'partial content',
+    headers: {
+      'content-range': 'bytes 0-14/30',
+      'content-type': 'text/plain; charset=utf-8',
+    },
+    statusCode: 206,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-400-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-400-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-400-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'The request was invalid.',
+    expectedText: 'The request was invalid.',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 400,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-401-json.ts
+++ b/packages/e2e/electron/src/simple-browser.response-401-json.ts
@@ -1,0 +1,13 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-401-json'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  const body = '{"error":"authentication required"}'
+  await ResponseTest.run(context, {
+    body,
+    expectedText: body,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    statusCode: 401,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-403-html.ts
+++ b/packages/e2e/electron/src/simple-browser.response-403-html.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-403-html'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: '<!doctype html><html><body><h1>Forbidden</h1><p>You cannot access this page.</p></body></html>',
+    expectedText: 'ForbiddenYou cannot access this page.',
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+    statusCode: 403,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-404-empty.ts
+++ b/packages/e2e/electron/src/simple-browser.response-404-empty.ts
@@ -1,0 +1,10 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-404-empty'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    expectedText: '',
+    statusCode: 404,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-404-json.ts
+++ b/packages/e2e/electron/src/simple-browser.response-404-json.ts
@@ -1,0 +1,13 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-404-json'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  const body = '{"error":"not found","status":404}'
+  await ResponseTest.run(context, {
+    body,
+    expectedText: body,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    statusCode: 404,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-404-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-404-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-404-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'The requested page was not found.',
+    expectedText: 'The requested page was not found.',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 404,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-405-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-405-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-405-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'Method Not Allowed',
+    expectedText: 'Method Not Allowed',
+    headers: { allow: 'POST', 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 405,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-408-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-408-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-408-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'Request Timeout',
+    expectedText: 'Request Timeout',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 408,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-409-json.ts
+++ b/packages/e2e/electron/src/simple-browser.response-409-json.ts
@@ -1,0 +1,13 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-409-json'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  const body = '{"error":"conflict"}'
+  await ResponseTest.run(context, {
+    body,
+    expectedText: body,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    statusCode: 409,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-410-html.ts
+++ b/packages/e2e/electron/src/simple-browser.response-410-html.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-410-html'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: '<!doctype html><html><body><h1>Gone</h1><p>This resource is no longer available.</p></body></html>',
+    expectedText: 'GoneThis resource is no longer available.',
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+    statusCode: 410,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-418-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-418-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-418-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: "I'm a teapot",
+    expectedText: "I'm a teapot",
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 418,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-422-json.ts
+++ b/packages/e2e/electron/src/simple-browser.response-422-json.ts
@@ -1,0 +1,13 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-422-json'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  const body = '{"error":"validation failed","fields":["name"]}'
+  await ResponseTest.run(context, {
+    body,
+    expectedText: body,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    statusCode: 422,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-429-empty.ts
+++ b/packages/e2e/electron/src/simple-browser.response-429-empty.ts
@@ -1,0 +1,11 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-429-empty'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    expectedText: '',
+    headers: { 'retry-after': '60' },
+    statusCode: 429,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-451-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-451-text.ts
@@ -1,0 +1,13 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-451-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'Unavailable For Legal Reasons',
+    expectedText: 'Unavailable For Legal Reasons',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 451,
+    statusMessage: 'Unavailable For Legal Reasons',
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-500-json.ts
+++ b/packages/e2e/electron/src/simple-browser.response-500-json.ts
@@ -1,0 +1,13 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-500-json'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  const body = '{"error":"internal server error","requestId":"test-123"}'
+  await ResponseTest.run(context, {
+    body,
+    expectedText: body,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+    statusCode: 500,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-500-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-500-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-500-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'Internal Server Error',
+    expectedText: 'Internal Server Error',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 500,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-502-html.ts
+++ b/packages/e2e/electron/src/simple-browser.response-502-html.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-502-html'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: '<!doctype html><html><body><h1>Bad Gateway</h1><p>The upstream server failed.</p></body></html>',
+    expectedText: 'Bad GatewayThe upstream server failed.',
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+    statusCode: 502,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-503-empty.ts
+++ b/packages/e2e/electron/src/simple-browser.response-503-empty.ts
@@ -1,0 +1,11 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-503-empty'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    expectedText: '',
+    headers: { 'retry-after': '120' },
+    statusCode: 503,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-504-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-504-text.ts
@@ -1,0 +1,12 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-504-text'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: 'Gateway Timeout',
+    expectedText: 'Gateway Timeout',
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+    statusCode: 504,
+  })
+}

--- a/packages/e2e/electron/src/simple-browser.response-chunked.ts
+++ b/packages/e2e/electron/src/simple-browser.response-chunked.ts
@@ -1,0 +1,22 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.response-chunked'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await TestServer.start((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+    response.write('first chunk, ')
+    setTimeout(() => {
+      response.end('second chunk')
+    }, 50)
+  })
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, server.url)
+    await expect(webContentsPage.locator('body')).toHaveText('first chunk, second chunk')
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.response-redirect.ts
+++ b/packages/e2e/electron/src/simple-browser.response-redirect.ts
@@ -1,0 +1,24 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.response-redirect'
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await TestServer.start((request, response) => {
+    if (request.url === '/redirect') {
+      response.writeHead(302, { location: '/destination' })
+      response.end()
+      return
+    }
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    response.end('<!doctype html><html><body><h1>Redirect destination</h1></body></html>')
+  })
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, `${server.url}/redirect`, `${server.url}/destination`)
+    await expect(webContentsPage.locator('h1')).toHaveText('Redirect destination')
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.response-unicode-html.ts
+++ b/packages/e2e/electron/src/simple-browser.response-unicode-html.ts
@@ -1,0 +1,11 @@
+import * as ResponseTest from './_responseTest.ts'
+
+export const name = 'simple-browser.response-unicode-html'
+
+export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
+  await ResponseTest.run(context, {
+    body: '<!doctype html><html><body><p>Grüße, 世界 — café ☕</p></body></html>',
+    expectedText: 'Grüße, 世界 — café ☕',
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  })
+}


### PR DESCRIPTION
Adds deterministic Electron e2e coverage for Simple Browser WebContents response rendering and navigation failures. Covers successful, redirect, chunked, 4xx, 5xx, empty-body, connection-error, and recovery scenarios with local HTTP fixtures.