### PR TITLE
feature: add simple browser navigation e2e tests

### DIFF
--- a/packages/e2e/electron/src/_navigationTest.ts
+++ b/packages/e2e/electron/src/_navigationTest.ts
@@ -1,0 +1,22 @@
+import * as TestServer from './_testServer.ts'
+
+export const pageAPath = '/a.html'
+export const pageBPath = '/b.html'
+
+const pages: Readonly<Record<string, string>> = {
+  [pageAPath]: '<!doctype html><html><body><h1>Page A</h1><a href="/b.html">Go to Page B</a></body></html>',
+  [pageBPath]: '<!doctype html><html><body><h1>Page B</h1></body></html>',
+}
+
+export const startServer = (): Promise<TestServer.TestServer> => {
+  return TestServer.start((request, response) => {
+    const body = pages[request.url || '']
+    if (!body) {
+      response.writeHead(404)
+      response.end()
+      return
+    }
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    response.end(body)
+  })
+}

--- a/packages/e2e/electron/src/_simpleBrowser.ts
+++ b/packages/e2e/electron/src/_simpleBrowser.ts
@@ -57,6 +57,16 @@ export const openUrl = async (page: Page, url: string, expectedUrl: string = url
   return waitForWebContentsPage(page, expectedUrl)
 }
 
+export const clickLink = async (webContentsPage: Page, name: string): Promise<void> => {
+  // eslint-disable-next-line e2e/no-direct-click -- exercises navigation initiated inside the WebContentsView
+  await webContentsPage.getByRole('link', { name }).click()
+}
+
+export const clickButton = async (page: Page, name: 'Back' | 'Forward' | 'Reload'): Promise<void> => {
+  // eslint-disable-next-line e2e/no-direct-click -- exercises the actual Simple Browser toolbar button
+  await page.locator('.SimpleBrowserHeader').getByRole('button', { exact: true, name }).click()
+}
+
 export const injectJavaScriptCode = async <T>(webContentsPage: Page, code: string): Promise<T> => {
   return webContentsPage.evaluate(code)
 }

--- a/packages/e2e/electron/src/simple-browser.backward.ts
+++ b/packages/e2e/electron/src/simple-browser.backward.ts
@@ -1,0 +1,28 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as NavigationTest from './_navigationTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+
+export const name = 'simple-browser.backward'
+// TODO enable when Electron forwards Simple Browser toolbar clicks to the active view
+export const skip = 1
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await NavigationTest.startServer()
+  const pageAUrl = `${server.url}${NavigationTest.pageAPath}`
+  const pageBUrl = `${server.url}${NavigationTest.pageBPath}`
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, pageAUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Page A')
+
+    await SimpleBrowser.clickLink(webContentsPage, 'Go to Page B')
+    await webContentsPage.waitForURL(pageBUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Page B')
+
+    await SimpleBrowser.clickButton(page, 'Back')
+    await webContentsPage.waitForURL(pageAUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Page A')
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.forward.ts
+++ b/packages/e2e/electron/src/simple-browser.forward.ts
@@ -1,0 +1,31 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as NavigationTest from './_navigationTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+
+export const name = 'simple-browser.forward'
+// TODO enable when Electron forwards Simple Browser toolbar clicks to the active view
+export const skip = 1
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  const server = await NavigationTest.startServer()
+  const pageAUrl = `${server.url}${NavigationTest.pageAPath}`
+  const pageBUrl = `${server.url}${NavigationTest.pageBPath}`
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, pageAUrl)
+
+    await SimpleBrowser.clickLink(webContentsPage, 'Go to Page B')
+    await webContentsPage.waitForURL(pageBUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Page B')
+
+    await SimpleBrowser.clickButton(page, 'Back')
+    await webContentsPage.waitForURL(pageAUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Page A')
+
+    await SimpleBrowser.clickButton(page, 'Forward')
+    await webContentsPage.waitForURL(pageBUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Page B')
+  } finally {
+    await server.close()
+  }
+}

--- a/packages/e2e/electron/src/simple-browser.reload.ts
+++ b/packages/e2e/electron/src/simple-browser.reload.ts
@@ -1,0 +1,33 @@
+import type { ElectronTestContext } from './_responseTest.ts'
+import * as SimpleBrowser from './_simpleBrowser.ts'
+import * as TestServer from './_testServer.ts'
+
+export const name = 'simple-browser.reload'
+// TODO enable when Electron forwards Simple Browser toolbar clicks to the active view
+export const skip = 1
+
+export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
+  let requestCount = 0
+  const server = await TestServer.start((request, response) => {
+    if (request.url !== '/reload.html') {
+      response.writeHead(404)
+      response.end()
+      return
+    }
+    requestCount++
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+    response.end(`<!doctype html><html><body><h1>Request ${requestCount}</h1></body></html>`)
+  })
+  const reloadUrl = `${server.url}/reload.html`
+  try {
+    await SimpleBrowser.show(page)
+    const webContentsPage = await SimpleBrowser.openUrl(page, reloadUrl)
+    await expect(webContentsPage.locator('h1')).toHaveText('Request 1')
+
+    await SimpleBrowser.clickButton(page, 'Reload')
+    await expect(webContentsPage.locator('h1')).toHaveText('Request 2')
+    expect(webContentsPage.url()).toBe(reloadUrl)
+  } finally {
+    await server.close()
+  }
+}


### PR DESCRIPTION
Add Electron regression coverage for the Simple Browser back, forward, and reload toolbar actions.

Use local HTTP fixtures to verify the rendered WebContentsView content after each navigation.