### PR TITLE
fix: skip flaky text response e2e test

### DIFF
--- a/packages/e2e/electron/src/simple-browser.response-200-text.ts
+++ b/packages/e2e/electron/src/simple-browser.response-200-text.ts
@@ -1,6 +1,8 @@
 import * as ResponseTest from './_responseTest.ts'
 
 export const name = 'simple-browser.response-200-text'
+// TODO enable when the Simple Browser reliably navigates between response-test server URLs
+export const skip = 1
 
 export const test = async (context: ResponseTest.ElectronTestContext): Promise<void> => {
   await ResponseTest.run(context, {


### PR DESCRIPTION
Temporarily disables the flaky Electron text-response scenario that can remain attached to the previous test server URL.