### PR TITLE
fix: disable Electron sandbox in dev script

### DIFF
--- a/packages/build/src/dev.js
+++ b/packages/build/src/dev.js
@@ -10,7 +10,7 @@ const main = async () => {
   execa(
     'npx',
 
-    ['electron', '.', '--wait'],
+    ['electron', '--no-sandbox', '.', '--wait'],
     {
       cwd: join(root, 'packages', 'server'),
       stdio: 'inherit',


### PR DESCRIPTION
Pass Electron’s `--no-sandbox` flag in the development launcher so a clean, user-owned install can start without a root-owned setuid sandbox helper. This matches the main editor development launcher.

Validation:
- `npm run dev` (Electron and watcher remain running)
- `npm run type-check`
- `npm test`
- `npm run lint`