### PR TITLE
feature: test browser tab audio mute toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  LVCE_ELECTRON_VERSION: v0.110.24
+  LVCE_ELECTRON_VERSION: v0.111.2
 
 on:
   push:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR
 
 env:
-  LVCE_ELECTRON_VERSION: v0.110.24
+  LVCE_ELECTRON_VERSION: v0.111.2
 
 on:
   pull_request:

--- a/packages/e2e/electron/src/simple-browser.audio-tab-indicator.ts
+++ b/packages/e2e/electron/src/simple-browser.audio-tab-indicator.ts
@@ -64,7 +64,21 @@ export const test = async ({ expect, page: editorPage }: ElectronTestContext): P
   await webContentsPage.getByRole('button', { name: 'Play' }).click()
   await expect(webContentsPage.locator('body')).toHaveAttribute('data-audio-state', 'playing')
   await expect(audioIndicator).toBeVisible()
-  await expect(audioIndicator).toHaveAttribute('title', 'This tab is playing audio')
+  await expect(audioIndicator).toHaveAttribute('aria-pressed', 'false')
+  await expect(audioIndicator).toHaveAttribute('title', 'Mute tab')
+  await expect(audioIndicator.locator('.MaskIconUnmute')).toBeVisible()
+
+  // eslint-disable-next-line e2e/no-direct-click -- exercises the audio indicator's mute toggle
+  await audioIndicator.click()
+  await expect(audioIndicator).toHaveAttribute('aria-pressed', 'true')
+  await expect(audioIndicator).toHaveAttribute('title', 'Unmute tab')
+  await expect(audioIndicator.locator('.MaskIconMute')).toBeVisible()
+
+  // eslint-disable-next-line e2e/no-direct-click -- exercises the audio indicator's unmute toggle
+  await audioIndicator.click()
+  await expect(audioIndicator).toHaveAttribute('aria-pressed', 'false')
+  await expect(audioIndicator).toHaveAttribute('title', 'Mute tab')
+  await expect(audioIndicator.locator('.MaskIconUnmute')).toBeVisible()
 
   // eslint-disable-next-line e2e/no-direct-click -- stops playback in the embedded page
   await webContentsPage.getByRole('button', { name: 'Stop' }).click()


### PR DESCRIPTION
## Summary

- exercise muting and unmuting a playing Simple Browser tab through its audio indicator
- verify the accessible pressed state, tooltip, and audio/muted icons
- run Electron E2E against LVCE v0.111.2