### PR TITLE
fix: open LVCE Editor from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "node packages/build/src/build.js",
     "build:static": "node packages/build/src/build-static.js",
-    "build:watch": "./packages/build/node_modules/.bin/esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --watch packages/simple-browser-view/src/simpleBrowserViewWorkerMain.ts --outfile=.tmp/dist/dist/simpleBrowserViewWorkerMain.js",
+    "build:watch": "./packages/build/node_modules/.bin/esbuild --format=esm --bundle --external:node:buffer --external:electron --external:ws --external:node:worker_threads --watch=forever packages/simple-browser-view/src/simpleBrowserViewWorkerMain.ts --outfile=.tmp/dist/dist/simpleBrowserViewWorkerMain.js",
     "dev": "node packages/build/src/dev.js",
     "format": "prettier --write .",
     "lint": "eslint . && knip --no-config-hints",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "measure": "node --experimental-strip-types src/measureMemory.ts",
-    "measure:visible": "node --experimental-strip-types src/measureMemory.ts --no-headless"
+    "measure:visible": "node --experimental-strip-types src/measureMemory.ts --no-headless",
+    "test": "node --test test/*.test.js"
   },
   "keywords": [],
   "author": "",

--- a/packages/build/src/dev.js
+++ b/packages/build/src/dev.js
@@ -1,26 +1,23 @@
 import { execa } from 'execa'
 import { root } from './root.js'
-import { join } from 'node:path'
+import { getDevApplicationCommand } from './getDevApplicationCommand.js'
+import { waitForDevProcesses } from './waitForDevProcesses.js'
 
 const main = async () => {
-  execa(`npm`, ['run', 'build:watch'], {
+  await execa('npm', ['run', 'build'], {
     cwd: root,
     stdio: 'inherit',
   })
-  execa(
-    'npx',
-
-    ['electron', '--no-sandbox', '.', '--wait'],
-    {
-      cwd: join(root, 'packages', 'server'),
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        LVCE_SHARED_PROCESS_PATH: join(root, 'node_modules', '@lvce-editor', 'shared-process', 'src', 'sharedProcessMain.js'),
-        LVCE_PRELOAD_URL: join(root, 'node_modules', '@lvce-editor', 'preload', 'src', 'index.js'),
-      },
-    },
-  )
+  const watcher = execa('npm', ['run', 'build:watch'], {
+    cwd: root,
+    stdio: 'inherit',
+  })
+  const { command, args, cwd } = getDevApplicationCommand(root)
+  const application = execa(command, args, {
+    cwd,
+    stdio: 'inherit',
+  })
+  await waitForDevProcesses({ application, watcher })
 }
 
-main()
+await main()

--- a/packages/build/src/getDevApplicationCommand.js
+++ b/packages/build/src/getDevApplicationCommand.js
@@ -1,0 +1,9 @@
+import { join } from 'node:path'
+
+export const getDevApplicationCommand = (root, executablePath = process.env.LVCE_EXECUTABLE_PATH || 'lvce') => {
+  return {
+    args: ['--link', join(root, '.tmp', 'dist'), '--hot-reload', '--wait', root],
+    command: executablePath,
+    cwd: root,
+  }
+}

--- a/packages/build/src/waitForDevProcesses.js
+++ b/packages/build/src/waitForDevProcesses.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {Promise<unknown> & { kill(signal: string): unknown }} ChildProcessPromise
+ * @typedef {{ off(event: string, listener: () => void): unknown, once(event: string, listener: () => void): unknown }} SignalEmitter
+ */
+
+/**
+ * @param {{ application: ChildProcessPromise, processObject?: SignalEmitter, watcher: ChildProcessPromise }} options
+ */
+export const waitForDevProcesses = async ({ application, processObject = process, watcher }) => {
+  let resolveSignal
+  const signal = new Promise((resolve) => {
+    resolveSignal = resolve
+  })
+  const handleSignal = () => {
+    resolveSignal()
+  }
+  processObject.once('SIGINT', handleSignal)
+  processObject.once('SIGTERM', handleSignal)
+  try {
+    await Promise.race([watcher, application, signal])
+  } finally {
+    processObject.off('SIGINT', handleSignal)
+    processObject.off('SIGTERM', handleSignal)
+    watcher.kill('SIGTERM')
+    application.kill('SIGTERM')
+    await Promise.allSettled([watcher, application])
+  }
+}

--- a/packages/build/src/waitForDevProcesses.js
+++ b/packages/build/src/waitForDevProcesses.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {Promise<unknown> & { kill(signal: string): unknown }} ChildProcessPromise
+ * @typedef {Promise<unknown> & { kill(signal?: NodeJS.Signals | number, error?: Error): unknown }} ChildProcessPromise
  * @typedef {{ off(event: string, listener: () => void): unknown, once(event: string, listener: () => void): unknown }} SignalEmitter
  */
 

--- a/packages/build/test/getDevApplicationCommand.test.js
+++ b/packages/build/test/getDevApplicationCommand.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import test from 'node:test'
+import { getDevApplicationCommand } from '../src/getDevApplicationCommand.js'
+import { waitForDevProcesses } from '../src/waitForDevProcesses.js'
+
+test('launches LVCE with the local simple browser worker linked', () => {
+  const root = '/test/simple-browser-view'
+
+  assert.deepEqual(getDevApplicationCommand(root, '/test/bin/lvce'), {
+    args: ['--link', join(root, '.tmp', 'dist'), '--hot-reload', '--wait', root],
+    command: '/test/bin/lvce',
+    cwd: root,
+  })
+})
+
+test('keeps the build watcher alive without an interactive stdin', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('../../../package.json', import.meta.url), 'utf8'))
+
+  assert.match(packageJson.scripts['build:watch'], /--watch=forever/)
+})
+
+test('terminates both child processes when the dev script is interrupted', async () => {
+  /** @type {string[]} */
+  const signals = []
+  /** @returns {Promise<void> & { kill(signal: string): void }} */
+  const createChild = () => {
+    let resolveChild = () => {}
+    /** @type {Promise<void>} */
+    const childPromise = new Promise((resolve) => {
+      resolveChild = resolve
+    })
+    return Object.assign(childPromise, {
+      kill(signal) {
+        signals.push(signal)
+        resolveChild()
+      },
+    })
+  }
+  const processObject = new EventEmitter()
+  const watcher = createChild()
+  const application = createChild()
+
+  const completion = waitForDevProcesses({ application, processObject, watcher })
+  processObject.emit('SIGINT')
+  await completion
+
+  assert.deepEqual(signals, ['SIGTERM', 'SIGTERM'])
+})

--- a/packages/build/test/getDevApplicationCommand.test.js
+++ b/packages/build/test/getDevApplicationCommand.test.js
@@ -25,19 +25,20 @@ test('keeps the build watcher alive without an interactive stdin', async () => {
 test('terminates both child processes when the dev script is interrupted', async () => {
   /** @type {string[]} */
   const signals = []
-  /** @returns {Promise<void> & { kill(signal: string): void }} */
+  /** @returns {Promise<void> & { kill(signal?: NodeJS.Signals | number, error?: Error): boolean }} */
   const createChild = () => {
     let resolveChild = () => {}
     /** @type {Promise<void>} */
     const childPromise = new Promise((resolve) => {
       resolveChild = resolve
     })
-    return Object.assign(childPromise, {
-      kill(signal) {
-        signals.push(signal)
-        resolveChild()
-      },
-    })
+    /** @param {NodeJS.Signals | number} [signal] */
+    const kill = (signal = 'SIGTERM') => {
+      signals.push(String(signal))
+      resolveChild()
+      return true
+    }
+    return Object.assign(childPromise, { kill })
   }
   const processObject = new EventEmitter()
   const watcher = createChild()


### PR DESCRIPTION
## Summary

- build the local Simple Browser worker before starting development
- launch the installed LVCE Editor with the local package linked and hot reload enabled
- keep the watcher alive without interactive stdin and terminate child processes on signals

## Validation

- 40 tests passed (37 worker tests + 3 dev-launcher tests)
- lint and type-check passed
- packaged LVCE workbench rendered from `npm run dev`
- `Simple Browser: Open` loaded Example Domain through the linked worker