### PR TITLE
fix: isolate simple browser dev profile

### DIFF
--- a/packages/build/src/getDevApplicationCommand.js
+++ b/packages/build/src/getDevApplicationCommand.js
@@ -2,7 +2,7 @@ import { join } from 'node:path'
 
 export const getDevApplicationCommand = (root, executablePath = process.env.LVCE_EXECUTABLE_PATH || 'lvce') => {
   return {
-    args: ['--link', join(root, '.tmp', 'dist'), '--hot-reload', '--wait', root],
+    args: ['--link', join(root, '.tmp', 'dist'), '--hot-reload', `--user-data-dir=${join(root, '.tmp', 'user-data')}`, '--wait', root],
     command: executablePath,
     cwd: root,
   }

--- a/packages/build/test/getDevApplicationCommand.test.js
+++ b/packages/build/test/getDevApplicationCommand.test.js
@@ -10,7 +10,7 @@ test('launches LVCE with the local simple browser worker linked', () => {
   const root = '/test/simple-browser-view'
 
   assert.deepEqual(getDevApplicationCommand(root, '/test/bin/lvce'), {
-    args: ['--link', join(root, '.tmp', 'dist'), '--hot-reload', '--wait', root],
+    args: ['--link', join(root, '.tmp', 'dist'), '--hot-reload', `--user-data-dir=${join(root, '.tmp', 'user-data')}`, '--wait', root],
     command: '/test/bin/lvce',
     cwd: root,
   })


### PR DESCRIPTION
## Summary

- launch Simple Browser development with a repository-local Electron user-data directory
- prevent an already-running installed LVCE instance from intercepting the development launch