### PR TITLE
feature: enable new tab input e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 env:
-  LVCE_ELECTRON_VERSION: v0.111.2
+  LVCE_ELECTRON_VERSION: v0.111.21
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,13 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         with:
           path: packages/e2e/.test-with-playwright/electron
-          key: ${{ runner.os }}-simple-browser-electron-${{ env.LVCE_ELECTRON_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-simple-browser-electron-${{ hashFiles('package-lock.json') }}
       - name: Electron e2e
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/e2e
         run: xvfb-run -a npm run e2e:electron
       - name: New tab input Electron e2e
-        if: matrix.os == 'ubuntu-24.04'
+        if: ${{ always() && matrix.os == 'ubuntu-24.04' }}
         working-directory: ./packages/e2e
         run: xvfb-run -a npm run e2e:electron -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: New tab input Electron e2e
         if: ${{ always() && matrix.os == 'ubuntu-24.04' }}
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
+        run: xvfb-run -a npm run e2e:electron:built-in -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
         env:
           RUN_NEW_TAB_INPUT_E2E: '1'
       - name: Start PulseAudio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Electron e2e
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron
+        run: xvfb-run -a npm run e2e:electron -- --electron-version=$LVCE_ELECTRON_VERSION
       - name: Start PulseAudio
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 env:
-  LVCE_ELECTRON_VERSION: v0.111.21
+  LVCE_ELECTRON_VERSION: v0.111.2
+  LVCE_NEW_TAB_INPUT_ELECTRON_VERSION: v0.111.21
 
 on:
   push:
@@ -72,7 +73,7 @@ jobs:
       - name: New tab input Electron e2e
         if: ${{ always() && matrix.os == 'ubuntu-24.04' }}
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron:built-in -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
+        run: xvfb-run -a npm run e2e:electron:built-in -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_NEW_TAB_INPUT_ELECTRON_VERSION
         env:
           RUN_NEW_TAB_INPUT_E2E: '1'
       - name: Start PulseAudio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,17 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         with:
           path: packages/e2e/.test-with-playwright/electron
-          key: ${{ runner.os }}-simple-browser-electron-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-simple-browser-electron-${{ env.LVCE_ELECTRON_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Electron e2e
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron -- --electron-version=$LVCE_ELECTRON_VERSION
+        run: xvfb-run -a npm run e2e:electron
+      - name: New tab input Electron e2e
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/e2e
+        run: xvfb-run -a npm run e2e:electron -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
+        env:
+          RUN_NEW_TAB_INPUT_E2E: '1'
       - name: Start PulseAudio
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,13 +55,13 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         with:
           path: packages/e2e/.test-with-playwright/electron
-          key: ${{ runner.os }}-simple-browser-electron-${{ env.LVCE_ELECTRON_VERSION }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-simple-browser-electron-${{ hashFiles('package-lock.json') }}
       - name: Electron e2e
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/e2e
         run: xvfb-run -a npm run e2e:electron
       - name: New tab input Electron e2e
-        if: matrix.os == 'ubuntu-24.04'
+        if: ${{ always() && matrix.os == 'ubuntu-24.04' }}
         working-directory: ./packages/e2e
         run: xvfb-run -a npm run e2e:electron -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,8 @@
 name: PR
 
 env:
-  LVCE_ELECTRON_VERSION: v0.111.21
+  LVCE_ELECTRON_VERSION: v0.111.2
+  LVCE_NEW_TAB_INPUT_ELECTRON_VERSION: v0.111.21
 
 on:
   pull_request:
@@ -63,7 +64,7 @@ jobs:
       - name: New tab input Electron e2e
         if: ${{ always() && matrix.os == 'ubuntu-24.04' }}
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron:built-in -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
+        run: xvfb-run -a npm run e2e:electron:built-in -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_NEW_TAB_INPUT_ELECTRON_VERSION
         env:
           RUN_NEW_TAB_INPUT_E2E: '1'
       - name: Start PulseAudio

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
 name: PR
 
 env:
-  LVCE_ELECTRON_VERSION: v0.111.2
+  LVCE_ELECTRON_VERSION: v0.111.21
 
 on:
   pull_request:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Electron e2e
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron
+        run: xvfb-run -a npm run e2e:electron -- --electron-version=$LVCE_ELECTRON_VERSION
       - name: Start PulseAudio
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ jobs:
       - name: New tab input Electron e2e
         if: ${{ always() && matrix.os == 'ubuntu-24.04' }}
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
+        run: xvfb-run -a npm run e2e:electron:built-in -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
         env:
           RUN_NEW_TAB_INPUT_E2E: '1'
       - name: Start PulseAudio

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,11 +55,17 @@ jobs:
         if: matrix.os == 'ubuntu-24.04'
         with:
           path: packages/e2e/.test-with-playwright/electron
-          key: ${{ runner.os }}-simple-browser-electron-${{ hashFiles('package-lock.json') }}
+          key: ${{ runner.os }}-simple-browser-electron-${{ env.LVCE_ELECTRON_VERSION }}-${{ hashFiles('package-lock.json') }}
       - name: Electron e2e
         if: matrix.os == 'ubuntu-24.04'
         working-directory: ./packages/e2e
-        run: xvfb-run -a npm run e2e:electron -- --electron-version=$LVCE_ELECTRON_VERSION
+        run: xvfb-run -a npm run e2e:electron
+      - name: New tab input Electron e2e
+        if: matrix.os == 'ubuntu-24.04'
+        working-directory: ./packages/e2e
+        run: xvfb-run -a npm run e2e:electron -- --filter=simple-browser.new-tab-input --electron-version=$LVCE_ELECTRON_VERSION
+        env:
+          RUN_NEW_TAB_INPUT_E2E: '1'
       - name: Start PulseAudio
         if: matrix.os == 'ubuntu-24.04'
         run: |

--- a/packages/e2e/electron/src/_simpleBrowser.ts
+++ b/packages/e2e/electron/src/_simpleBrowser.ts
@@ -57,7 +57,7 @@ export const show = async (page: Page): Promise<void> => {
   const command = quickPick.getByRole('option', { exact: true, name: 'Simple Browser: Open' })
   await command.waitFor({ state: 'visible' })
   await page.keyboard.press('Enter')
-  await page.locator('.SimpleBrowser').waitFor({ state: 'visible' })
+  await page.locator('.SimpleBrowser').last().waitFor({ state: 'visible' })
 }
 
 export const setUrl = async (page: Page, url: string): Promise<void> => {

--- a/packages/e2e/electron/src/simple-browser.new-tab-input.ts
+++ b/packages/e2e/electron/src/simple-browser.new-tab-input.ts
@@ -2,6 +2,7 @@ import type { ElectronTestContext } from './_responseTest.ts'
 import * as SimpleBrowser from './_simpleBrowser.ts'
 
 export const name = 'simple-browser.new-tab-input'
+export const skip = process.env.RUN_NEW_TAB_INPUT_E2E === '1' ? 0 : 1
 
 export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
   await SimpleBrowser.show(page)

--- a/packages/e2e/electron/src/simple-browser.new-tab-input.ts
+++ b/packages/e2e/electron/src/simple-browser.new-tab-input.ts
@@ -2,8 +2,6 @@ import type { ElectronTestContext } from './_responseTest.ts'
 import * as SimpleBrowser from './_simpleBrowser.ts'
 
 export const name = 'simple-browser.new-tab-input'
-// TODO enable when the published Electron editor includes the new tab input user-select style
-export const skip = 1
 
 export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
   await SimpleBrowser.show(page)

--- a/packages/e2e/electron/src/simple-browser.new-tab-input.ts
+++ b/packages/e2e/electron/src/simple-browser.new-tab-input.ts
@@ -6,6 +6,9 @@ export const skip = process.env.RUN_NEW_TAB_INPUT_E2E === '1' ? 0 : 1
 
 export const test = async ({ expect, page }: ElectronTestContext): Promise<void> => {
   await SimpleBrowser.show(page)
+  const simpleBrowser = page.locator('.SimpleBrowser').last()
+  // eslint-disable-next-line e2e/no-direct-click -- exercises the actual new-tab control
+  await simpleBrowser.getByRole('button', { exact: true, name: 'New Tab' }).click()
   const newTabPage = await SimpleBrowser.waitForWebContentsPage(page, 'data:text/html')
   const input = newTabPage.getByRole('searchbox', { name: 'Search with Google' })
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "e2e": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=.",
     "e2e:electron": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --electron --only-extension=. --test-path=./electron --timeout=60000",
+    "e2e:electron:built-in": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js --electron --only-extension=./extension --test-path=./electron --timeout=60000",
     "e2e:headless": "node ./node_modules/@lvce-editor/test-with-playwright/bin/test-with-playwright.js  --only-extension=. --test-path=. --headless",
     "type-check": "tsc"
   },


### PR DESCRIPTION
Run the Simple Browser new-tab input computed-style regression against LVCE v0.111.21, which includes the user-select fix.