### PR TITLE
fix: contribute simple browser tab hover setting

### DIFF
--- a/packages/build/src/build.js
+++ b/packages/build/src/build.js
@@ -72,3 +72,4 @@ await writeJson(join(dist, 'package.json'), packageJson)
 
 await cp(join(root, 'README.md'), join(dist, 'README.md'))
 await cp(join(root, 'LICENSE'), join(dist, 'LICENSE'))
+await cp(join(root, 'packages', 'simple-browser-view', 'settings.json'), join(dist, 'dist', 'settings.json'))

--- a/packages/build/test/buildSettings.test.js
+++ b/packages/build/test/buildSettings.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+test('includes the simple browser settings contribution in the build', async () => {
+  const settings = JSON.parse(await readFile(new URL('../../../.tmp/dist/dist/settings.json', import.meta.url), 'utf8'))
+
+  assert.deepEqual(settings.find(({ id }) => id === 'simpleBrowser.tabHover.enabled'), {
+    category: 'features',
+    description: 'Controls whether hovering over a simple browser tab shows its full title and memory usage',
+    heading: 'Simple Browser Tab Hover',
+    id: 'simpleBrowser.tabHover.enabled',
+    type: 'boolean',
+    value: false,
+  })
+})

--- a/packages/simple-browser-view/settings.json
+++ b/packages/simple-browser-view/settings.json
@@ -1,0 +1,10 @@
+[
+  {
+    "category": "features",
+    "description": "Controls whether hovering over a simple browser tab shows its full title and memory usage",
+    "heading": "Simple Browser Tab Hover",
+    "id": "simpleBrowser.tabHover.enabled",
+    "type": "boolean",
+    "value": false
+  }
+]


### PR DESCRIPTION
Publishes the simpleBrowser.tabHover.enabled settings contribution with the Simple Browser worker package so LVCE can recognize it in settings.json.